### PR TITLE
13.0 mig fix analytic tag dimension enhanced

### DIFF
--- a/analytic_tag_dimension_enhanced/models/__init__.py
+++ b/analytic_tag_dimension_enhanced/models/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
 from . import analytic
+from . import analytic_dimension_line

--- a/analytic_tag_dimension_enhanced/models/analytic.py
+++ b/analytic_tag_dimension_enhanced/models/analytic.py
@@ -159,9 +159,11 @@ class AccountAnalyticTag(models.Model):
         string="Record",
     )
 
-    def _check_analytic_dimension(self):
-        super()._check_analytic_dimension()
-        # Test all required dimension is selected
+    def _check_required_dimension(self, record):
+        """ Test all required dimension is selected (exclude non-invoice) """
+        record.ensure_one()
+        if "exclude_from_invoice_tab" in record and record.exclude_from_invoice_tab:
+            return
         Dimension = self.env["account.analytic.dimension"]
         req_dimensions = Dimension.search([("required", "=", True)])
         tags_dimension = self.filtered("analytic_dimension_id.required")

--- a/analytic_tag_dimension_enhanced/models/analytic_dimension_line.py
+++ b/analytic_tag_dimension_enhanced/models/analytic_dimension_line.py
@@ -1,0 +1,21 @@
+# Copyright 2019 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AnalyticDimensionLine(models.AbstractModel):
+    _inherit = "analytic.dimension.line"
+
+    @api.model_create_multi
+    def create(self, vals):
+        res = super().create(vals)
+        for rec in res:
+            rec[self._analytic_tag_field_name]._check_required_dimension(rec)
+        return res
+
+    def write(self, vals):
+        res = super().write(vals)
+        for rec in self:
+            rec[self._analytic_tag_field_name]._check_required_dimension(rec)
+        return res

--- a/analytic_tag_dimension_enhanced/views/account_move_view.xml
+++ b/analytic_tag_dimension_enhanced/views/account_move_view.xml
@@ -18,7 +18,7 @@
             >
                 <attribute
                     name="domain"
-                >['|', ('id', 'in', domain_tag_ids or []), ('analytic_dimension_id.by_sequence', '=', False)]</attribute>
+                >[('id', 'in', domain_tag_ids or [])]</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Prior to this fix, following step will fail.

3 dimensions, only 1 dimension is required.
On the invoice line, select the required dimension and save, still show Error required dimension.
This is because, when save an invoice line, there will be more than one line created. And on those line, the required tag is not set.

It is not possible anymore to inherit _check_analytic_dimension and add required dimension test. We need to pass the invoice line record itself to test first that, the exclude_from_invoice_tab = False to continue testing.
